### PR TITLE
Fix input-file suffix stripping (B1) and convert_to_bool parsing (B4)

### DIFF
--- a/app/star_pass/_helpers.py
+++ b/app/star_pass/_helpers.py
@@ -2,7 +2,6 @@
 """ Helper methods for star_pass.py """
 
 # Imports - Python Standard Library
-from ast import literal_eval
 from datetime import datetime, timedelta
 from typing import Any, Dict
 from pprint import pprint as pp
@@ -61,28 +60,52 @@ class Helpers:
         # Exit the program
         sys.exit(status_code)
 
+    # Accepted string representations for each boolean value.
+    _TRUE_STRINGS = frozenset({'true', 't', 'yes', 'y', '1'})
+    _FALSE_STRINGS = frozenset({'false', 'f', 'no', 'n', '0'})
+
     def convert_to_bool(
             self,
             arg_value: str
-    ) -> str:
+    ) -> bool:
         """ Convert a string representation of a boolean to a bool.
+
+            Comparison is case-insensitive and ignores surrounding
+            whitespace. Unrecognized values raise a ValueError rather
+            than defaulting, so that a typo (e.g. 'flase') can never
+            silently send live API requests.
 
             Args:
                 arg_value (str):
-                    String representation of a boolean.
+                    String representation of a boolean. Accepted
+                    (case-insensitive) values are:
+                        True:  'true', 't', 'yes', 'y', '1'
+                        False: 'false', 'f', 'no', 'n', '0'
+
+            Raises:
+                ValueError:
+                    If 'arg_value' is not a recognized boolean string.
 
             Returns:
                 arg_bool (bool):
                     bool object converted from a string.
         """
 
-        # Normalize the string capitalization of 'bool_dict_value'
-        arg_value = arg_value.lower().capitalize()
+        # Normalize the string for comparison
+        normalized = arg_value.strip().lower()
 
-        # Convert `bool_dict_value` to a boolean
-        arg_bool = literal_eval(arg_value)
+        # Map the normalized value to a boolean
+        if normalized in self._TRUE_STRINGS:
+            return True
+        if normalized in self._FALSE_STRINGS:
+            return False
 
-        return arg_bool
+        # Fail fast on unrecognized input
+        accepted = sorted(self._TRUE_STRINGS | self._FALSE_STRINGS)
+        raise ValueError(
+            f'Cannot convert {arg_value!r} to a boolean. '
+            f'Accepted values (case-insensitive): {accepted}.'
+        )
 
     def format_date_time_amplify(
             self,

--- a/app/star_pass/amplify_shifts.py
+++ b/app/star_pass/amplify_shifts.py
@@ -153,8 +153,10 @@ class CreateShifts:  # pylint: disable=too-many-instance-attributes
             # Set the simplest valid verbosity level
             self.output_verbosity = VERBOSITY_LEVELS[0]
 
-        # Set the base file name
-        self.base_file_name = input_file.rstrip(INPUT_FILE_EXTENSION)
+        # Set the base file name.
+        # Use removesuffix (not rstrip, which strips a *character set*
+        # and would corrupt names ending in '.', 'c', 's', or 'v').
+        self.base_file_name = input_file.removesuffix(INPUT_FILE_EXTENSION)
 
         # Set the input file path
         self.input_file = Path.joinpath(

--- a/tests/test_amplify_shifts.py
+++ b/tests/test_amplify_shifts.py
@@ -1,0 +1,38 @@
+""" Tests for star_pass.amplify_shifts.CreateShifts.
+
+    Focused on input-file name handling. CreateShifts is constructed
+    with auto_prep_data=False so that no CSV is read and no network
+    call is made during __init__.
+"""
+# pylint: disable=missing-function-docstring,missing-class-docstring
+
+# Imports - Local
+from star_pass.amplify_shifts import CreateShifts
+
+
+class TestBaseFileName:
+    def test_strips_csv_suffix(self):
+        shifts = CreateShifts(
+            input_file='gcal_shifts_2099-01-01T00_00_00_000000.csv',
+            auto_prep_data=False
+        )
+        assert shifts.base_file_name == (
+            'gcal_shifts_2099-01-01T00_00_00_000000'
+        )
+
+    def test_only_removes_the_suffix_not_a_character_set(self):
+        # Regression for the previous rstrip('.csv') bug, which stripped
+        # any trailing '.', 'c', 's', or 'v' characters. removesuffix
+        # must remove only the exact '.csv' extension.
+        shifts = CreateShifts(
+            input_file='shifts_scv.csv',
+            auto_prep_data=False
+        )
+        assert shifts.base_file_name == 'shifts_scv'
+
+    def test_output_file_uses_json_extension(self):
+        shifts = CreateShifts(
+            input_file='shifts_scv.csv',
+            auto_prep_data=False
+        )
+        assert shifts.output_file.name == 'shifts_scv.json'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -19,10 +19,29 @@ class TestConvertToBool:
             ('false', False),
             ('True', True),
             ('False', False),
+            ('  TRUE  ', True),
+            ('yes', True),
+            ('y', True),
+            ('t', True),
+            ('1', True),
+            ('no', False),
+            ('n', False),
+            ('f', False),
+            ('0', False),
         ]
     )
     def test_valid_boolean_strings(self, helpers, value, expected):
         assert helpers.convert_to_bool(value) is expected
+
+    @pytest.mark.parametrize(
+        'value',
+        ['maybe', 'flase', '', '2', 'tru', 'noo']
+    )
+    def test_invalid_input_raises_value_error(self, helpers, value):
+        # Fail fast: a typo must never be silently coerced (e.g. so a
+        # mistyped check_mode can't accidentally send live requests).
+        with pytest.raises(ValueError):
+            helpers.convert_to_bool(value)
 
 
 class TestDateTimeFormatting:


### PR DESCRIPTION
- amplify_shifts: use removesuffix instead of rstrip for the .csv suffix
- _helpers: convert_to_bool maps explicit truthy/falsy strings and raises ValueError on unrecognized input; drop unused literal_eval
- Add tests/test_amplify_shifts.py; extend convert_to_bool tests

Fixes #135 