### PR TITLE
Paginate Google Calendar results and guard missing items (B2)

### DIFF
--- a/app/star_pass/gcal_data.py
+++ b/app/star_pass/gcal_data.py
@@ -428,25 +428,40 @@ class GCALData:
         # Loop over keywords to construct consolidated results
         for query_string in query_strings:
 
-            # Update the 'q' query string parameter
+            # Update the 'q' query string parameter and reset pagination
+            # so a page token from a previous query does not carry over.
             params.update({'q': query_string})
+            params.pop('pageToken', None)
 
-            # Construct API request data
-            api_request_data = {
-                'method': method,
-                'url': url,
-                'headers': headers,
-                'params': params,
-                'timeout': timeout
-            }
+            # Page through every result set for this query string. The
+            # Google Calendar API returns a 'nextPageToken' whenever more
+            # results are available (the default page size is 250).
+            while True:
 
-            # Send API request
-            response = self.helpers.send_api_request(
-                api_request_data=api_request_data
-            )
+                # Construct API request data
+                api_request_data = {
+                    'method': method,
+                    'url': url,
+                    'headers': headers,
+                    'params': params,
+                    'timeout': timeout
+                }
 
-            # Add matching results to `gcal_shift_data`
-            gcal_shift_data += response.json().get('items')
+                # Send API request
+                response = self.helpers.send_api_request(
+                    api_request_data=api_request_data
+                )
+                response_json = response.json()
+
+                # Add matching results to `gcal_shift_data`, defaulting
+                # to an empty list when the 'items' key is absent.
+                gcal_shift_data += response_json.get('items') or []
+
+                # Stop unless the response supplies a next page token.
+                next_page_token = response_json.get('nextPageToken')
+                if not next_page_token:
+                    break
+                params.update({'pageToken': next_page_token})
 
         return gcal_shift_data
 

--- a/tests/test_gcal_data.py
+++ b/tests/test_gcal_data.py
@@ -7,6 +7,10 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
 # pylint: disable=protected-access,redefined-outer-name
 
+# Imports - Python Standard Library
+import copy
+from unittest.mock import Mock
+
 # Imports - Third-Party
 import pytest
 
@@ -18,6 +22,14 @@ from star_pass.gcal_data import GCALData
 def gcal() -> GCALData:
     # auto_prep_data=False prevents any Google Calendar API calls.
     return GCALData(gcal_name='practices', auto_prep_data=False)
+
+
+def _mock_response(payload: dict) -> Mock:
+    # Build a stand-in for a requests.Response whose .json() returns
+    # the supplied payload.
+    response = Mock()
+    response.json.return_value = payload
+    return response
 
 
 class TestGetShiftTimeData:
@@ -47,3 +59,56 @@ class TestGetShiftTimeData:
             '2025-04-09T18:00:00-07:00'
         )
         assert result == ('2025-04-09', '18:00', 120)
+
+
+class TestGetGcalShiftData:
+    # The 'events' calendar has a single query string, which keeps the
+    # pagination assertions focused on the page loop itself.
+
+    def test_follows_next_page_token(self, monkeypatch):
+        gcal = GCALData(gcal_name='events', auto_prep_data=False)
+        pages = [
+            _mock_response(
+                {'items': [{'id': 'a'}], 'nextPageToken': 'PAGE2'}
+            ),
+            _mock_response(
+                {'items': [{'id': 'b'}]}
+            ),
+        ]
+        seen_params = []
+
+        def fake_send(api_request_data, **_kwargs):
+            # Snapshot params per call; the method mutates one dict.
+            seen_params.append(copy.deepcopy(api_request_data['params']))
+            return pages[len(seen_params) - 1]
+
+        monkeypatch.setattr(gcal.helpers, 'send_api_request', fake_send)
+
+        result = gcal.get_gcal_shift_data(
+            timeMin='2099-01-01T00:00:00-00:00',
+            timeMax='2099-01-31T00:00:00-00:00'
+        )
+
+        # Items from both pages are accumulated in order.
+        assert result == [{'id': 'a'}, {'id': 'b'}]
+        # Two requests: the initial page and the next-page follow-up.
+        assert len(seen_params) == 2
+        assert 'pageToken' not in seen_params[0]
+        assert seen_params[1]['pageToken'] == 'PAGE2'
+
+    def test_missing_items_key_does_not_raise(self, monkeypatch):
+        gcal = GCALData(gcal_name='events', auto_prep_data=False)
+        response = _mock_response({})  # no 'items', no 'nextPageToken'
+
+        monkeypatch.setattr(
+            gcal.helpers,
+            'send_api_request',
+            lambda **_kwargs: response
+        )
+
+        result = gcal.get_gcal_shift_data(
+            timeMin='2099-01-01T00:00:00-00:00',
+            timeMax='2099-01-31T00:00:00-00:00'
+        )
+
+        assert result == []


### PR DESCRIPTION
- get_gcal_shift_data now follows nextPageToken so result sets larger than one page are no longer silently truncated
- Default missing 'items' to an empty list instead of crashing
- Add mocked pagination and missing-items tests

Fixes #136 