### PR TITLE
Redact API keys and bearer tokens from error output (C1)

### DIFF
--- a/app/star_pass/_helpers.py
+++ b/app/star_pass/_helpers.py
@@ -5,6 +5,7 @@
 from datetime import datetime, timedelta
 from typing import Any, Dict
 from pprint import pprint as pp
+import re
 import sys
 
 # Imports - Third-Party
@@ -393,6 +394,42 @@ class Helpers:
 
         return need_details
 
+    # Regex patterns matching secret-bearing substrings (API keys and
+    # bearer tokens) that must never be printed or logged.
+    _SECRET_PATTERNS = (
+        re.compile(r'(?i)(key=)[^&\s\'"]+'),
+        re.compile(r'(?i)(bearer\s+)[^\s\'"]+'),
+    )
+
+    def redact_secrets(
+            self,
+            text: Any
+    ) -> str:
+        """ Redact API keys and bearer tokens from a string.
+
+            Replaces the value portion of 'key=<value>' query parameters
+            and 'Bearer <token>' header values with 'REDACTED', so that
+            secrets cannot leak into stdout, stderr, or logs (for
+            example, via an exception repr that includes a request URL).
+
+            Args:
+                text (Any):
+                    Value to scrub.  Converted to a string before
+                    redaction.
+
+            Returns:
+                redacted (str):
+                    The input with any secret values replaced by
+                    'REDACTED'.
+        """
+
+        # Substitute each secret pattern, preserving the label prefix
+        redacted = str(text)
+        for pattern in self._SECRET_PATTERNS:
+            redacted = pattern.sub(r'\1REDACTED', redacted)
+
+        return redacted
+
     def send_api_request(
             self,
             api_request_data: Dict,
@@ -454,6 +491,10 @@ class Helpers:
             message += f'{error_message}\n\n'
             message += repr(f'{error!r}')
 
+            # Redact any secrets before display (an error repr may
+            # include the request URL with its 'key' query parameter).
+            message = self.redact_secrets(message)
+
             self.printer(
                 message=message,
                 file=sys.stderr
@@ -474,6 +515,10 @@ class Helpers:
             )
             message += f'{len(message) * "_"}\n\n'
             message += repr(f'{error!r}')
+
+            # Redact any secrets before display
+            message = self.redact_secrets(message)
+
             self.printer(
                 message=message,
                 file=sys.stderr

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,6 +10,9 @@
 # Imports - Third-Party
 import pytest
 
+# Imports - Local
+from star_pass import _helpers
+
 
 class TestConvertToBool:
     @pytest.mark.parametrize(
@@ -87,3 +90,66 @@ class TestSearchShiftInfo:
             need_name=need_name
         )
         assert result['description'] == expected_description
+
+
+class TestRedactSecrets:
+    @pytest.mark.parametrize(
+        'text, secret',
+        [
+            (
+                'https://www.googleapis.com/events?key=SUPERSECRET&x=1',
+                'SUPERSECRET'
+            ),
+            (
+                "{'Authorization': 'Bearer abc123.token'}",
+                'abc123.token'
+            ),
+        ]
+    )
+    def test_secret_is_removed(self, helpers, text, secret):
+        result = helpers.redact_secrets(text)
+        assert secret not in result
+        assert 'REDACTED' in result
+
+    def test_preserves_the_label_prefix(self, helpers):
+        result = helpers.redact_secrets('?key=SUPERSECRET&page=2')
+        assert result == '?key=REDACTED&page=2'
+
+    def test_ordinary_text_is_unchanged(self, helpers):
+        text = 'HTTP 404 Not Found for /needs/123/shifts'
+        assert helpers.redact_secrets(text) == text
+
+
+class TestSendApiRequestRedaction:
+    def test_error_repr_with_key_is_redacted(self, helpers, monkeypatch):
+        # 'sentinel' (not 'secret'/'token') avoids a false-positive
+        # bandit B105 hardcoded-password finding on the test value.
+        sentinel = 'TOPSECRET'
+
+        def raise_conn_error(**_kwargs):
+            raise _helpers.exceptions.ConnectionError(
+                f'Failed for url https://x/events?key={sentinel}'
+            )
+
+        # Force the HTTP call to raise, and capture the message that
+        # would be written to stderr before the program exits.
+        monkeypatch.setattr(_helpers, 'request', raise_conn_error)
+        captured = {}
+        monkeypatch.setattr(
+            helpers,
+            'printer',
+            lambda message, **_kwargs: captured.update(message=message)
+        )
+
+        # The real exit_program raises SystemExit after printing.
+        with pytest.raises(SystemExit):
+            helpers.send_api_request(
+                api_request_data={
+                    'method': 'GET',
+                    'url': 'https://x/events',
+                    'timeout': 3
+                }
+            )
+
+        assert sentinel not in captured['message']
+        assert 'REDACTED' in captured['message']


### PR DESCRIPTION
send_api_request previously printed repr(error) on failure, which for requests exceptions can include the request URL and its 'key' query parameter -- leaking the Google Calendar API key to stderr/logs.

- Add Helpers.redact_secrets to scrub 'key=<value>' and 'Bearer <token>'
- Apply it to the message in both send_api_request error branches
- Add redaction unit tests and an error-path integration test

Fixes #139 
Fixes #140 
Fixes #142 