### PR TITLE
Bump version to 1.5.0 to open Phase 2

### DIFF
--- a/app/__version__.py
+++ b/app/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 """ star_pass package version file. """
 
-__version__ = '1.4.10'
+__version__ = '1.5.0'


### PR DESCRIPTION
Open the Phase 2 (best practices / twelve-factor) work with a single minor version bump. Phase 2 is a batch of backwards-compatible enhancements (env-configurable deployment values, argparse CLI, logging, HTTP retry, pinned dependencies, fuzzy-match confidence threshold), so a minor bump is the semver-appropriate marker for the start of the phase.

pyproject.toml resolves the project version from app.__version__ via [tool.setuptools.dynamic], so no other file needs to change.