### PR TITLE
Extract deployment config to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,37 @@
+# star-pass environment configuration template.
+#
+# Copy this file to `.env` and fill in the required values:
+#
+#     cp .env.example .env
+#
+# Only the two API credentials are required.  Every other value is an
+# optional override; when unset, the defaults in
+# app/star_pass/_defaults.py apply, so the tool works out of the box for
+# Rose City Rollers.  Other organizations can override the deployment
+# values below without editing any code.
+
+# --- Required: API credentials ---
+# Amplify (Galaxy Digital) API bearer token.
+AMPLIFY_TOKEN=your-amplify-api-token
+# Google Calendar API key.
+GCAL_TOKEN=your-google-calendar-api-key
+
+# --- Optional: API endpoints ---
+# BASE_AMPLIFY_URL=https://api.galaxydigital.com/api
+# BASE_GCAL_URL=https://www.googleapis.com/calendar/v3/calendars
+
+# --- Optional: HTTP behavior ---
+# Request timeout in whole seconds.
+# HTTP_TIMEOUT=3
+
+# --- Optional: Google Calendar IDs (organization specific) ---
+# GCAL_EVENTS_CAL_ID=your-events-calendar-id@resource.calendar.google.com
+# GCAL_PRACTICES_CAL_ID=your-practices-calendar-id@resource.calendar.google.com
+
+# --- Optional: Google Calendar query strings (comma-separated) ---
+# GCAL_EVENTS_QUERY_STRINGS=
+# GCAL_PRACTICES_QUERY_STRINGS=officials,scrimmage
+
+# --- Optional: Google Calendar search window (ISO 8601) ---
+# GCAL_TIME_MIN=2099-01-01T00:00:00-00:00
+# GCAL_TIME_MAX=2099-01-31T00:00:00-00:00

--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,8 @@ celerybeat.pid
 # Environments
 .env
 .env.*
+# Keep the tracked, secret-free configuration template.
+!.env.example
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ This tool automates bulk operations on the Galaxy Digital Amplify volunteer mana
 
 1. Clone the GitHub repository.
 2. Open the Development Container in Visual Studio Code.
-3. Create a file named `.env` at the root directory with the following variables and their corresponding values:
+3. Create a `.env` file at the root directory by copying the tracked template and filling in your values:
 
-    ```text
-    AMPLIFY_TOKEN=<insert_amplify_token>         ## Amplify API Token
-    GCAL_TOKEN=<insert_gcal_token>               ## Google Calendar API Token
-    GCAL_TIME_MIN = '2099-01-10T00:00:00-00:00'  ## "From" date for Google Calendar shift searches
-    GCAL_TIME_MAX = '2099-01-30T00:00:00-00:00'  ## "To" date for Google Calendar shift searches
+    ```bash
+    cp .env.example .env
     ```
+
+    Only `AMPLIFY_TOKEN` and `GCAL_TOKEN` are required. Deployment values such as the API URLs, HTTP timeout, and Google Calendar IDs and query strings are optional overrides; when unset, the defaults in `app/star_pass/_defaults.py` apply. Every supported variable is documented in `.env.example`.
 
 ## Usage
 

--- a/app/star_pass/_defaults.py
+++ b/app/star_pass/_defaults.py
@@ -2,10 +2,13 @@
 """ star_pass default values. """
 
 # Imports - Python Standard Library
+from os import getenv
 from pathlib import Path
+from typing import List
 import sys
 
 # Imports - Third-Party
+from dotenv import load_dotenv
 from yaml import safe_load
 
 # Date and time formatting
@@ -26,6 +29,40 @@ RUN_MODES = (
 FILE_ENCODING = sys.getfilesystemencoding()
 # .env file path
 ENV_FILE_PATH = './.env'
+# Load environment variables so the deployment values defined below can
+# be overridden via the environment (twelve-factor config).  Values
+# already present in the environment are not overridden by the .env file.
+load_dotenv(
+    dotenv_path=ENV_FILE_PATH,
+    encoding=FILE_ENCODING
+)
+
+
+def _get_env_list(
+        var_name: str,
+        default: List[str]
+) -> List[str]:
+    """ Read a comma-separated environment variable as a list.
+
+        Args:
+            var_name (str):
+                Name of the environment variable to read.
+
+            default (List[str]):
+                Value to return when the variable is unset.
+
+        Returns:
+            List[str]:
+                The comma-separated values as a list of stripped
+                strings, or 'default' when the variable is unset.
+    """
+
+    raw_value = getenv(var_name)
+    if raw_value is None:
+        return default
+    return [item.strip() for item in raw_value.split(',')]
+
+
 # Path relative to this file
 CURRENT_FILE_PATH = Path(__file__).parent
 # 'app' directory path
@@ -72,9 +109,20 @@ BASE_HEADERS = {
     'Accept': 'application/json',
     'Content-Type': 'application/json'
 }
-BASE_AMPLIFY_URL = 'https://api.galaxydigital.com/api'
-BASE_GCAL_URL = 'https://www.googleapis.com/calendar/v3/calendars'
-HTTP_TIMEOUT = 3
+BASE_AMPLIFY_URL = getenv(
+    'BASE_AMPLIFY_URL',
+    'https://api.galaxydigital.com/api'
+)
+BASE_GCAL_URL = getenv(
+    'BASE_GCAL_URL',
+    'https://www.googleapis.com/calendar/v3/calendars'
+)
+HTTP_TIMEOUT = int(
+    getenv(
+        'HTTP_TIMEOUT',
+        '3'
+    )
+)
 
 # Google Calendar values
 BASE_GCAL_ENDPOINT = '/events'
@@ -83,13 +131,14 @@ GCAL_SHOW_DELETED = 'false'
 GCAL_SINGLE_EVENTS = 'true'
 GCAL_TIME_MIN = '2025-01-01T00:00:00-00:00'
 GCAL_TIME_MAX = '2025-02-09T00:00:00-00:00'
-GCAL_EVENTS_QUERY_STRINGS = [
-    ''
-]
-GCAL_PRACTICES_QUERY_STRINGS = [
-    'officials',
-    'scrimmage'
-]
+GCAL_EVENTS_QUERY_STRINGS = _get_env_list(
+    'GCAL_EVENTS_QUERY_STRINGS',
+    ['']
+)
+GCAL_PRACTICES_QUERY_STRINGS = _get_env_list(
+    'GCAL_PRACTICES_QUERY_STRINGS',
+    ['officials', 'scrimmage']
+)
 BASE_GCAL_PARAMS = {
     'orderBy': GCAL_ORDER_BY,
     'q': '',
@@ -99,13 +148,15 @@ BASE_GCAL_PARAMS = {
     'timeMax': '',
 }
 GCAL_ID_PREFIX = '/rosecityrollers.com_'
-GCAL_EVENTS_CAL_ID = (
+GCAL_EVENTS_CAL_ID = getenv(
+    'GCAL_EVENTS_CAL_ID',
     (
         f'{GCAL_ID_PREFIX}'
         '2d35383436363030372d363035@resource.calendar.google.com'
     )
 )
-GCAL_PRACTICES_CAL_ID = (
+GCAL_PRACTICES_CAL_ID = getenv(
+    'GCAL_PRACTICES_CAL_ID',
     (
         f'{GCAL_ID_PREFIX}'
         '313938323232323331%40resource.calendar.google.com'


### PR DESCRIPTION
Make the org- and deployment-specific values in _defaults.py overridable via the environment (twelve-factor config), so other organizations can run the tool without editing code. Load the .env file at the top of _defaults.py so the getenv() reads below pick up overrides, then wrap the Amplify/Google Calendar base URLs, HTTP timeout, Google Calendar IDs, and per-calendar query strings in getenv() with their current values as fallbacks. Query strings parse from a comma-separated string via a small _get_env_list() helper. HTTP_TIMEOUT is cast to int.

Existing environment variables are not overridden by the .env file, so test fixtures and real deployments keep control.

Add a secret-free .env.example template documenting every supported variable, negate it in .gitignore so it stays tracked, and point the README setup steps at it.