### PR TITLE
Replace hand-rolled CLI parsing with argparse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,13 +32,16 @@ through the Amplify API. It is run once per month.
 ## Running the workflow
 
 ```bash
-# 1. Collect Google Calendar events into a timestamped CSV.
-./app/__main__.py --mode=get_gcal_events gcal_name=practices
-./app/__main__.py --mode=get_gcal_events gcal_name=events
+# Run modes are argparse subcommands (aliases: c, g). Use --help or
+# <mode> --help for details.
 
-# 2. Create Amplify shifts from a CSV (check_mode=True is a dry run).
-./app/__main__.py --mode=create_amplify_shifts \
-  --input_file=gcal_shifts_<timestamp>.csv --check_mode=True
+# 1. Collect Google Calendar events into a timestamped CSV.
+./app/__main__.py get_gcal_events --gcal-name practices
+./app/__main__.py get_gcal_events --gcal-name events
+
+# 2. Create Amplify shifts from a CSV (--check-mode true is a dry run).
+./app/__main__.py create_amplify_shifts \
+  --input-file gcal_shifts_<timestamp>.csv --check-mode true
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -38,18 +38,23 @@ This tool automates bulk operations on the Galaxy Digital Amplify volunteer mana
 
 ## Usage
 
+Run `./app/__main__.py --help` to list the run modes, or `./app/__main__.py <mode> --help` for the options of a specific mode. Each mode has a single-letter alias (`c` and `g`).
+
 1. Collect Google Calendar Shift data and save shift data in a formatted CSV file:
 
     ```bash
     # Get events from the "Practices" calendar
-    ./app/__main__.py --mode=get_gcal_events gcal_name=practices
+    ./app/__main__.py get_gcal_events --gcal-name practices
 
     # Get events from the "Events" calendar
-    ./app/__main__.py --mode=get_gcal_events gcal_name=events
+    ./app/__main__.py get_gcal_events --gcal-name events
     ```
 
 2. Create Amplify Shifts using formatted CSV file data:
 
     ```bash
-    ./app/__main__.py --mode=create_amplify_shifts --input_file=gcal_shifts_2099-01-01T00_00_00_000000.csv check_mode=False
+    # Dry run (default); add --check-mode false to send live requests
+    ./app/__main__.py create_amplify_shifts \
+        --input-file gcal_shifts_2099-01-01T00_00_00_000000.csv \
+        --check-mode false
     ```

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -2,8 +2,8 @@
 """ Main application script. """
 
 # Imports - Python Standard Library
-from sys import argv
-from typing import Dict
+import argparse
+from typing import Optional, Sequence
 
 # Imports - Local
 from star_pass.amplify_shifts import CreateShifts
@@ -12,118 +12,166 @@ from star_pass._helpers import Helpers
 from star_pass import _defaults
 
 # Constants
-RUN_MODES = _defaults.RUN_MODES
+VERBOSITY_LEVELS = _defaults.VERBOSITY_LEVELS
+# Valid Google Calendar names, derived from the configured calendars so
+# the choices stay in sync with any deployment overrides.
+GCAL_NAMES = tuple(_defaults.GCAL_CALENDARS)
 
 # Initialize helper methods
 helpers = Helpers()
 
 
-# Check for CLI arguments
-def get_cli_args() -> Dict[str, str]:
-    """ Check for CLI arguments.
+# argparse boolean type converter
+def _bool_arg(
+        value: str
+) -> bool:
+    """ Parse a boolean CLI value, reusing the shared converter.
+
+        Wraps 'Helpers.convert_to_bool' so an unrecognized value raises
+        'argparse.ArgumentTypeError', letting argparse surface the
+        converter's message (which lists the accepted spellings).
+
+        Args:
+            value (str):
+                Raw argument value.
+
+        Raises:
+            argparse.ArgumentTypeError:
+                If 'value' is not a recognized boolean string.
+
+        Returns:
+            bool:
+                The parsed boolean value.
+    """
+
+    try:
+        return helpers.convert_to_bool(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+
+
+# Build the command-line argument parser
+def build_parser() -> argparse.ArgumentParser:
+    """ Build the command-line argument parser.
+
+        Defines a subcommand per run mode ('create_amplify_shifts' and
+        'get_gcal_events', each with a single-letter alias) so the tool
+        exposes a real '--help', validates arguments, and returns a
+        non-zero exit code on misuse.
 
         Args:
             None.
 
         Returns:
-            args (Dict[str, str]):
-                Dict of CLI arguments and their values that map to Dict
-                keys and values, respectively.
+            parser (argparse.ArgumentParser):
+                The configured top-level argument parser.
     """
 
-    # Create a Dict to store args
-    cli_args = {}
+    parser = argparse.ArgumentParser(
+        prog='star-pass',
+        description=(
+            'Automate volunteer-shift management in Galaxy Digital '
+            'Amplify.'
+        )
+    )
 
-    if len(argv) > 1:
-        # Slice the file name from the list of arguments
-        arg_list = argv[1:]
+    # A run mode is required; each subcommand carries its own arguments.
+    subparsers = parser.add_subparsers(
+        dest='mode',
+        required=True,
+        metavar='mode'
+    )
 
-        # Parse keys and values from arg_list to add to the 'args' Dict
-        for arg in arg_list:
-            # Split the argument and its value to separate variables
-            arg_key, arg_value = arg.split('=')
+    # Run mode: create Amplify shifts from a CSV file (alias: c)
+    create_parser = subparsers.add_parser(
+        'create_amplify_shifts',
+        aliases=['c'],
+        help='Create Amplify shifts from a formatted CSV file.'
+    )
+    create_parser.add_argument(
+        '--input-file',
+        required=True,
+        help='Name of the CSV file to read shift data from.'
+    )
+    create_parser.add_argument(
+        '--check-mode',
+        type=_bool_arg,
+        default=True,
+        metavar='{true,false}',
+        help='Prepare requests without sending them. Default: true.'
+    )
+    create_parser.add_argument(
+        '--output-verbosity',
+        choices=VERBOSITY_LEVELS,
+        default=VERBOSITY_LEVELS[0],
+        help=f'Amount of detail to display. Default: {VERBOSITY_LEVELS[0]}.'
+    )
 
-            # Remove leading '-' chars and strip outer spaces from 'arg_key'
-            arg_key = arg_key.lstrip('-').strip()
+    # Run mode: collect Google Calendar events into a CSV file (alias: g)
+    gcal_parser = subparsers.add_parser(
+        'get_gcal_events',
+        aliases=['g'],
+        help='Collect events from a Google Calendar into a CSV file.'
+    )
+    gcal_parser.add_argument(
+        '--gcal-name',
+        required=True,
+        choices=GCAL_NAMES,
+        help='Name of the Google Calendar to collect events from.'
+    )
 
-            # Strip outer spaces from 'arg_value'
-            arg_value = arg_value.strip()
-
-            # Add `arg_key` and `arg_value` to the `args` Dict
-            cli_args.update({arg_key: arg_value})
-
-    return cli_args
+    return parser
 
 
 # Main application function definition
-def main() -> None:
+def main(
+        argv: Optional[Sequence[str]] = None
+) -> None:
     """ Main application.
 
         Args:
+            argv (Optional[Sequence[str]]):
+                Argument list to parse.  Defaults to None, which parses
+                'sys.argv'.  Primarily an injection point for tests.
+
+        Returns:
             None.
-
-        Returns None.
-
     """
 
-    # Get CLI arguments
-    cli_args = get_cli_args()
+    # Parse CLI arguments (argparse exits non-zero on invalid input)
+    parser = build_parser()
+    args = parser.parse_args(argv)
 
-    # Display help
-    # Add app usage instructions
-
-    # Initially set the run mode to invalid
-    run_mode_valid = False
-
-    # Determine the validity of the 'mode' argument
-    run_mode = cli_args.get('mode', '').lower()
-    if run_mode in RUN_MODES:
-        # Set the run mode to valid
-        run_mode_valid = True
-
-    # Run the application in the specified mode
-    if run_mode_valid is True:
-
-        # Run the application in 'create_amplify_shifts' mode
-        if run_mode in ('create_amplify_shifts', 'c'):
-            # Create and display the output message
-            output_message = (
-                '\n\n** Run mode is "Create Amplify Shifts" **\n'
-            )
-            helpers.printer(
-                message=output_message
-            )
-            # Create CreateShifts object
-            shifts = CreateShifts(
-                **cli_args
-            )
-            # Create shifts
-            shifts.create_new_shifts()
-
-        # Run the application in 'get_gcal_events' mode
-        if run_mode in ('get_gcal_events', 'g'):
-            # Create and display the output message
-            output_message = (
-                '\n\n** Run mode is "Get Google Calendar Events" **\n'
-            )
-            helpers.printer(
-                message=output_message
-            )
-            # Create CreateShifts object
-            GCALData(
-                **cli_args
-            )
-
-    # Display usage instructions and exit if the mode is unset or invalid
-    else:
-        # Create output message
+    # Run the application in 'create_amplify_shifts' mode
+    if args.mode in ('create_amplify_shifts', 'c'):
+        # Create and display the output message
         output_message = (
-            '\n\n** Invalid or unset "mode" argument **\n'
+            '\n\n** Run mode is "Create Amplify Shifts" **\n'
         )
-
-        # Display output message
         helpers.printer(
             message=output_message
+        )
+        # Create CreateShifts object
+        shifts = CreateShifts(
+            input_file=args.input_file,
+            check_mode=args.check_mode,
+            output_verbosity=args.output_verbosity
+        )
+        # Create shifts
+        shifts.create_new_shifts()
+
+    # Run the application in 'get_gcal_events' mode
+    elif args.mode in ('get_gcal_events', 'g'):
+        # Create and display the output message
+        output_message = (
+            '\n\n** Run mode is "Get Google Calendar Events" **\n'
+        )
+        helpers.printer(
+            message=output_message
+        )
+        # Create GCALData object
+        GCALData(
+            gcal_name=args.gcal_name
         )
 
     return None

--- a/app/star_pass/_defaults.py
+++ b/app/star_pass/_defaults.py
@@ -17,14 +17,6 @@ FILE_NAME_DATE_TIME_FORMAT = '%Y-%m-%dT%H_%M_%S_%f'
 SIMPLE_DATE_FORMAT = '%A, %B %d %Y'
 SIMPLE_TIME_FORMAT = '%H:%M'
 
-# Application run modes
-RUN_MODES = (
-    'create_amplify_shifts',
-    'c',  # Alias for 'create_amplify_shifts
-    'get_gcal_events',
-    'g'  # Alias for 'get_gcal_events'
-)
-
 # Data file management
 FILE_ENCODING = sys.getfilesystemencoding()
 # .env file path

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,10 +3,12 @@
     __main__.py is normally executed as a script, so it is loaded here
     by file path. CreateShifts, GCALData, and the module-level helpers
     object are replaced with mocks so that main() exercises only the
-    run-mode dispatch and banner output -- no CSV is read, no API call
-    is made, and banner text is asserted via the mocked printer (the
-    real printer binds sys.stdout at import time, which defeats stdout
-    capture fixtures).
+    argument parsing, run-mode dispatch, and banner output -- no CSV is
+    read, no API call is made, and banner text is asserted via the
+    mocked printer (the real printer binds sys.stdout at import time,
+    which defeats stdout capture fixtures). The mocked helpers keeps the
+    real convert_to_bool so that --check-mode parsing is exercised for
+    real.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring
 # pylint: disable=redefined-outer-name
@@ -18,6 +20,9 @@ from unittest.mock import Mock
 
 # Imports - Third-Party
 import pytest
+
+# Imports - Local
+from star_pass._helpers import Helpers
 
 # Path to the entry-point module.
 _MAIN_PATH = Path(__file__).resolve().parent.parent / 'app' / '__main__.py'
@@ -35,10 +40,13 @@ def app_main():
     spec.loader.exec_module(module)
 
     # Replace collaborators so main() performs no real work and banner
-    # output is observable through the mocked printer.
+    # output is observable through the mocked printer. Preserve the real
+    # convert_to_bool so argparse validates --check-mode as in production.
+    mock_helpers = Mock()
+    mock_helpers.convert_to_bool = Helpers().convert_to_bool
+    module.helpers = mock_helpers
     module.CreateShifts = Mock()
     module.GCALData = Mock()
-    module.helpers = Mock()
     return module
 
 
@@ -52,28 +60,96 @@ def _printed(app_main) -> str:
 
 class TestMainRunModeBanners:
     def test_create_mode_prints_banner_and_runs(self, app_main):
-        app_main.argv = [
-            'prog', 'mode=create_amplify_shifts', 'input_file=x.csv'
-        ]
-        app_main.main()
+        app_main.main(
+            ['create_amplify_shifts', '--input-file', 'x.csv']
+        )
 
         printed = _printed(app_main)
         assert 'Run mode is "Create Amplify Shifts"' in printed
-        app_main.CreateShifts.assert_called_once()
+        app_main.CreateShifts.assert_called_once_with(
+            input_file='x.csv',
+            check_mode=True,
+            output_verbosity='basic'
+        )
+        app_main.CreateShifts.return_value.create_new_shifts \
+            .assert_called_once()
+
+    def test_create_mode_alias_and_options(self, app_main):
+        app_main.main(
+            [
+                'c',
+                '--input-file', 'x.csv',
+                '--check-mode', 'false',
+                '--output-verbosity', 'simple'
+            ]
+        )
+
+        app_main.CreateShifts.assert_called_once_with(
+            input_file='x.csv',
+            check_mode=False,
+            output_verbosity='simple'
+        )
 
     def test_get_mode_prints_banner_and_runs(self, app_main):
-        app_main.argv = ['prog', 'mode=get_gcal_events', 'gcal_name=events']
-        app_main.main()
+        app_main.main(['get_gcal_events', '--gcal-name', 'events'])
 
         printed = _printed(app_main)
         assert 'Run mode is "Get Google Calendar Events"' in printed
-        app_main.GCALData.assert_called_once()
+        app_main.GCALData.assert_called_once_with(gcal_name='events')
 
-    def test_invalid_mode_prints_message_and_runs_nothing(self, app_main):
-        app_main.argv = ['prog', 'mode=bogus']
-        app_main.main()
+    def test_get_mode_alias(self, app_main):
+        app_main.main(['g', '--gcal-name', 'practices'])
 
-        printed = _printed(app_main)
-        assert 'Invalid or unset' in printed
+        app_main.GCALData.assert_called_once_with(gcal_name='practices')
+
+
+class TestMainArgumentErrors:
+    def test_missing_mode_exits_nonzero(self, app_main):
+        with pytest.raises(SystemExit) as exc_info:
+            app_main.main([])
+        assert exc_info.value.code != 0
         app_main.CreateShifts.assert_not_called()
         app_main.GCALData.assert_not_called()
+
+    def test_invalid_mode_exits_nonzero(self, app_main):
+        with pytest.raises(SystemExit) as exc_info:
+            app_main.main(['bogus'])
+        assert exc_info.value.code != 0
+
+    def test_missing_required_input_file_exits_nonzero(self, app_main):
+        with pytest.raises(SystemExit) as exc_info:
+            app_main.main(['create_amplify_shifts'])
+        assert exc_info.value.code != 0
+        app_main.CreateShifts.assert_not_called()
+
+    def test_invalid_check_mode_value_exits_nonzero(self, app_main):
+        with pytest.raises(SystemExit) as exc_info:
+            app_main.main(
+                [
+                    'create_amplify_shifts',
+                    '--input-file', 'x.csv',
+                    '--check-mode', 'maybe'
+                ]
+            )
+        assert exc_info.value.code != 0
+
+    def test_invalid_verbosity_choice_exits_nonzero(self, app_main):
+        with pytest.raises(SystemExit) as exc_info:
+            app_main.main(
+                [
+                    'create_amplify_shifts',
+                    '--input-file', 'x.csv',
+                    '--output-verbosity', 'loud'
+                ]
+            )
+        assert exc_info.value.code != 0
+
+    def test_invalid_gcal_name_choice_exits_nonzero(self, app_main):
+        with pytest.raises(SystemExit) as exc_info:
+            app_main.main(['get_gcal_events', '--gcal-name', 'nope'])
+        assert exc_info.value.code != 0
+
+    def test_help_exits_zero(self, app_main):
+        with pytest.raises(SystemExit) as exc_info:
+            app_main.main(['--help'])
+        assert exc_info.value.code == 0


### PR DESCRIPTION
The previous key=value parser (arg.split('=')) crashed on any token without exactly one '=', offered no --help, let typos fall through to deep TypeErrors, silently reset an invalid verbosity to the default, and returned exit code 0 on an invalid or unset run mode.

Rebuild the entry point with argparse: one subcommand per run mode (create_amplify_shifts/c, get_gcal_events/g), a real --help at both the top level and per mode, choices-validated --output-verbosity and --gcal-name, a required --input-file, and a --check-mode converter that reuses Helpers.convert_to_bool (wrapped so argparse surfaces the accepted spellings). Invalid input now exits non-zero.

main() takes an optional argv for testability and passes only the explicit, parsed arguments to CreateShifts/GCALData instead of forwarding an untyped kwargs blob. Derive the valid Google Calendar names from _defaults.GCAL_CALENDARS and drop the now-unused RUN_MODES constant.

Rewrite the entry-point tests for the new interface (dispatch, aliases, option parsing, and every argument-error exit path) and update the README and CLAUDE.md usage examples to the new syntax.

Fixes #71 