### PR TITLE
Route diagnostics and status through the logging framework

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ GCAL_TOKEN=your-google-calendar-api-key
 # Request timeout in whole seconds.
 # HTTP_TIMEOUT=3
 
+# --- Optional: Logging ---
+# Minimum log level: DEBUG, INFO, WARNING, ERROR, or CRITICAL.
+# LOG_LEVEL=INFO
+
 # --- Optional: Google Calendar IDs (organization specific) ---
 # GCAL_EVENTS_CAL_ID=your-events-calendar-id@resource.calendar.google.com
 # GCAL_PRACTICES_CAL_ID=your-practices-calendar-id@resource.calendar.google.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,9 @@ through the Amplify API. It is run once per month.
 - `app/star_pass/_helpers.py` — shared helpers (`Helpers`), including
   `send_api_request`.
 - `app/star_pass/_defaults.py` — central configuration and constants.
+- `app/star_pass/_logging.py` — package logger setup (`get_logger`);
+  level via the `LOG_LEVEL` environment variable. Diagnostics and status
+  flow through `logging`; report data still uses `Helpers.printer`.
 - `models/shift_info.yml` — keyword-to-need-ID data model.
 - `app/schema/amplify.shifts.schema.json` — JSON Schema for shift
   payloads.

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -9,6 +9,7 @@ from typing import Optional, Sequence
 from star_pass.amplify_shifts import CreateShifts
 from star_pass.gcal_data import GCALData
 from star_pass._helpers import Helpers
+from star_pass._logging import get_logger
 from star_pass import _defaults
 
 # Constants
@@ -19,6 +20,9 @@ GCAL_NAMES = tuple(_defaults.GCAL_CALENDARS)
 
 # Initialize helper methods
 helpers = Helpers()
+
+# Application logger
+logger = get_logger('star_pass.main')
 
 
 # argparse boolean type converter
@@ -144,12 +148,9 @@ def main(
 
     # Run the application in 'create_amplify_shifts' mode
     if args.mode in ('create_amplify_shifts', 'c'):
-        # Create and display the output message
-        output_message = (
-            '\n\n** Run mode is "Create Amplify Shifts" **\n'
-        )
-        helpers.printer(
-            message=output_message
+        # Announce the run mode
+        logger.info(
+            'Run mode is "Create Amplify Shifts"'
         )
         # Create CreateShifts object
         shifts = CreateShifts(
@@ -162,12 +163,9 @@ def main(
 
     # Run the application in 'get_gcal_events' mode
     elif args.mode in ('get_gcal_events', 'g'):
-        # Create and display the output message
-        output_message = (
-            '\n\n** Run mode is "Get Google Calendar Events" **\n'
-        )
-        helpers.printer(
-            message=output_message
+        # Announce the run mode
+        logger.info(
+            'Run mode is "Get Google Calendar Events"'
         )
         # Create GCALData object
         GCALData(

--- a/app/star_pass/_defaults.py
+++ b/app/star_pass/_defaults.py
@@ -116,6 +116,12 @@ HTTP_TIMEOUT = int(
     )
 )
 
+# Logging configuration
+LOG_LEVEL = getenv(
+    'LOG_LEVEL',
+    'INFO'
+)
+
 # Google Calendar values
 BASE_GCAL_ENDPOINT = '/events'
 GCAL_ORDER_BY = 'startTime'

--- a/app/star_pass/_helpers.py
+++ b/app/star_pass/_helpers.py
@@ -16,6 +16,7 @@ from requests import exceptions, request, Response
 
 # Imports - Local
 from . import _defaults
+from ._logging import get_logger
 
 # Constants
 AMPLIFY_DATE_TIME_FORMAT = _defaults.AMPLIFY_DATE_TIME_FORMAT
@@ -25,6 +26,9 @@ GCAL_CALENDARS = _defaults.GCAL_CALENDARS
 SHIFTS_INFO = _defaults.SHIFTS_INFO
 SIMPLE_DATE_FORMAT = _defaults.SIMPLE_DATE_FORMAT
 SIMPLE_TIME_FORMAT = _defaults.SIMPLE_TIME_FORMAT
+
+# Module logger
+logger = get_logger(__name__)
 
 
 # Class definitions
@@ -258,18 +262,10 @@ class Helpers:
         try:
             gcal_id = GCAL_CALENDARS[gcal_name]
 
-        # Display an error and exit if the 'gcal_name' lookup fails
+        # Log an error and exit if the 'gcal_name' lookup fails
         except KeyError:
-            message = (
-                f'\n** Error: "{gcal_name}" '
-                'is not a valid calendar name **\n'
-            )
-
-            # Display the error message and exit
-            self.printer(
-                message=message,
-                file=sys.stderr
-            )
+            message = f'"{gcal_name}" is not a valid calendar name'
+            logger.error(message)
             self.exit_program(status_code=1)
 
         return gcal_id
@@ -309,7 +305,7 @@ class Helpers:
             self,
             message: Any,
             end: str = '\n',
-            file=sys.stdout,
+            file=None,
             pretty_print: bool = False
     ) -> None:
         """ Message printer.
@@ -324,8 +320,10 @@ class Helpers:
                     'True'.
 
                 file (_io.TextIOWrapper, optional):
-                    Target for the output stream.  Default
-                    'sys.stdout'.
+                    Target for the output stream.  Default 'None', which
+                    resolves to the current 'sys.stdout' at call time so
+                    that stdout redirection (for example, pytest's capsys
+                    or capfd) is respected.
 
                 pretty_print (bool):
                     Display the output using 'pprint.pprint'.  Default
@@ -334,6 +332,11 @@ class Helpers:
             Returns:
                 None.
         """
+
+        # Resolve the output stream at call time rather than binding
+        # 'sys.stdout' once as a default argument value.
+        if file is None:
+            file = sys.stdout
 
         # Print formatted output
         if pretty_print is False:
@@ -479,26 +482,18 @@ class Helpers:
             exceptions.TooManyRedirects,
             exceptions.RequestException
         ) as error:
-            # Display the error text and exit
+            # Log the error text and exit
             try:
                 error_message = error.args[0].reason.args[0].rsplit(">: ")[1]
             # Handle non-standard errors
             except AttributeError:
                 error_message = 'Unspecified'
 
-            message = '\n\n** An HTTP Error Occurred **\n'
-            message += f'{len(message) * "_"}\n\n'
-            message += f'{error_message}\n\n'
-            message += repr(f'{error!r}')
-
-            # Redact any secrets before display (an error repr may
+            # Redact any secrets before logging (an error repr may
             # include the request URL with its 'key' query parameter).
-            message = self.redact_secrets(message)
-
-            self.printer(
-                message=message,
-                file=sys.stderr
-            )
+            detail = self.redact_secrets(f'{error_message} {error!r}')
+            message = f'An HTTP error occurred: {detail}'
+            logger.error(message)
             self.exit_program(status_code=1)
 
         # Check for HTTP errors
@@ -508,24 +503,16 @@ class Helpers:
 
         # Handle non-ok HTTP responses
         except exceptions.HTTPError as error:
-            # Display the error text and exit
+            # Redact any secrets before logging
+            detail = self.redact_secrets(repr(f'{error!r}'))
             message = (
-                '\n\n** The request returned a bad status code '
-                f'({response.status_code}) **\n'
+                'The request returned a bad status code '
+                f'({response.status_code}): {detail}'
             )
-            message += f'{len(message) * "_"}\n\n'
-            message += repr(f'{error!r}')
-
-            # Redact any secrets before display
-            message = self.redact_secrets(message)
-
-            self.printer(
-                message=message,
-                file=sys.stderr
-            )
+            logger.error(message)
             self.exit_program(status_code=1)
 
-        # Display the HTTP request status
+        # Log the HTTP request status
         if display_request_status is True:
             # Create display URL that does not expose any paths or parameters
             display_url = response.request.url.replace(
@@ -533,22 +520,11 @@ class Helpers:
                 ''
             )
 
-            # Set HTTP response output message
-            output_heading = (
-                '** HTTP API Response **\n'
-                f'URL: {display_url}\n'
-                f'Response: HTTP {response.status_code} {response.reason}'
+            message = (
+                f'HTTP API response: {display_url} -> '
+                f'HTTP {response.status_code} {response.reason}'
             )
-
-            # Create output message
-            output_message = (
-                f'\n{output_heading}\n'
-            )
-
-            # Display output message
-            self.printer(
-                message=output_message
-            )
+            logger.info(message)
 
         return response
 

--- a/app/star_pass/_logging.py
+++ b/app/star_pass/_logging.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+""" Logging configuration for the star_pass package.
+
+    Provides a single, idempotently-configured package logger so that
+    diagnostic and status output flows through the standard 'logging'
+    framework instead of bare 'print' calls.  The log level is read from
+    the 'LOG_LEVEL' environment variable (see _defaults), defaulting to
+    'INFO'.  User-facing report data (shift previews, JSON) is still
+    written with 'Helpers.printer'.
+"""
+
+# Imports - Python Standard Library
+import logging
+import sys
+
+# Imports - Local
+from . import _defaults
+
+# Constants
+PACKAGE_LOGGER_NAME = 'star_pass'
+LOG_LEVEL = _defaults.LOG_LEVEL
+LOG_FORMAT = '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+
+
+def _resolve_level(
+        level_name: str
+) -> int:
+    """ Convert a level name to a 'logging' level value.
+
+        Args:
+            level_name (str):
+                Case-insensitive level name (for example, 'INFO').
+
+        Returns:
+            int:
+                The matching 'logging' level, or 'logging.INFO' when
+                'level_name' is not a recognized level.
+    """
+
+    return getattr(
+        logging,
+        level_name.strip().upper(),
+        logging.INFO
+    )
+
+
+def configure_logging() -> logging.Logger:
+    """ Configure and return the package logger.
+
+        Idempotent: repeated calls do not attach duplicate handlers.
+        The logger keeps 'propagate' enabled so test fixtures (pytest's
+        'caplog') can capture records; in production the root logger has
+        no handler, so output is not duplicated.
+
+        Args:
+            None.
+
+        Returns:
+            logging.Logger:
+                The configured 'star_pass' package logger.
+    """
+
+    logger = logging.getLogger(PACKAGE_LOGGER_NAME)
+    if not logger.handlers:
+        handler = logging.StreamHandler(stream=sys.stderr)
+        handler.setFormatter(logging.Formatter(LOG_FORMAT))
+        logger.addHandler(handler)
+        logger.setLevel(_resolve_level(LOG_LEVEL))
+
+    return logger
+
+
+def get_logger(
+        name: str = PACKAGE_LOGGER_NAME
+) -> logging.Logger:
+    """ Return a configured logger.
+
+        Args:
+            name (str, optional):
+                Logger name.  Defaults to the package logger name.  Pass
+                a dotted child name (for example, '__name__' from a
+                module inside the package) to tag records with their
+                source while still routing through the package handler.
+
+        Returns:
+            logging.Logger:
+                A configured logger for 'name'.
+    """
+
+    configure_logging()
+    return logging.getLogger(name)

--- a/app/star_pass/gcal_data.py
+++ b/app/star_pass/gcal_data.py
@@ -8,7 +8,6 @@ from math import floor
 from os import getenv
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
-import sys
 
 # Imports - Third-Party
 from pandas import DataFrame as df
@@ -16,6 +15,7 @@ from pandas import DataFrame as df
 # Imports - Local
 from . import _defaults
 from ._helpers import Helpers, load_env_file
+from ._logging import get_logger
 
 # Load environment variables
 load_env_file()
@@ -55,6 +55,9 @@ DEFAULT_GCAL_TIME_MAX = getenv(
     'GCAL_TIME_MAX',
     _defaults.GCAL_TIME_MAX
 )
+
+# Module logger
+logger = get_logger(__name__)
 
 
 class GCALShift:
@@ -403,12 +406,9 @@ class GCALData:
 
         # Confirm the Google calendar variables are not None
         if gcal_id is None or query_strings is None:
-            # Display an error message and exit
-            message = '\n** Invalid Google Calendar Data **\n'
-            self.helpers.printer(
-                message=message,
-                file=sys.stderr
-            )
+            # Log an error message and exit
+            message = f'Invalid Google Calendar data for "{self.gcal_name}"'
+            logger.error(message)
             self.helpers.exit_program(status_code=1)
 
         # Construct URL

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -7,6 +7,9 @@
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring
 
+# Imports - Python Standard Library
+import logging
+
 # Imports - Third-Party
 import pytest
 
@@ -121,7 +124,9 @@ class TestRedactSecrets:
 
 
 class TestSendApiRequestRedaction:
-    def test_error_repr_with_key_is_redacted(self, helpers, monkeypatch):
+    def test_error_repr_with_key_is_redacted(
+            self, helpers, monkeypatch, caplog
+    ):
         # 'sentinel' (not 'secret'/'token') avoids a false-positive
         # bandit B105 hardcoded-password finding on the test value.
         sentinel = 'TOPSECRET'
@@ -131,25 +136,20 @@ class TestSendApiRequestRedaction:
                 f'Failed for url https://x/events?key={sentinel}'
             )
 
-        # Force the HTTP call to raise, and capture the message that
-        # would be written to stderr before the program exits.
+        # Force the HTTP call to raise, and capture the error record
+        # that is logged before the program exits.
         monkeypatch.setattr(_helpers, 'request', raise_conn_error)
-        captured = {}
-        monkeypatch.setattr(
-            helpers,
-            'printer',
-            lambda message, **_kwargs: captured.update(message=message)
-        )
 
-        # The real exit_program raises SystemExit after printing.
-        with pytest.raises(SystemExit):
-            helpers.send_api_request(
-                api_request_data={
-                    'method': 'GET',
-                    'url': 'https://x/events',
-                    'timeout': 3
-                }
-            )
+        # The real exit_program raises SystemExit after logging.
+        with caplog.at_level(logging.ERROR, logger='star_pass'):
+            with pytest.raises(SystemExit):
+                helpers.send_api_request(
+                    api_request_data={
+                        'method': 'GET',
+                        'url': 'https://x/events',
+                        'timeout': 3
+                    }
+                )
 
-        assert sentinel not in captured['message']
-        assert 'REDACTED' in captured['message']
+        assert sentinel not in caplog.text
+        assert 'REDACTED' in caplog.text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,7 @@
 
 # Imports - Python Standard Library
 import importlib.util
+import logging
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -50,22 +51,14 @@ def app_main():
     return module
 
 
-def _printed(app_main) -> str:
-    # Join every message passed to helpers.printer().
-    return '\n'.join(
-        call.kwargs.get('message', '')
-        for call in app_main.helpers.printer.call_args_list
-    )
-
-
 class TestMainRunModeBanners:
-    def test_create_mode_prints_banner_and_runs(self, app_main):
-        app_main.main(
-            ['create_amplify_shifts', '--input-file', 'x.csv']
-        )
+    def test_create_mode_logs_banner_and_runs(self, app_main, caplog):
+        with caplog.at_level(logging.INFO, logger='star_pass'):
+            app_main.main(
+                ['create_amplify_shifts', '--input-file', 'x.csv']
+            )
 
-        printed = _printed(app_main)
-        assert 'Run mode is "Create Amplify Shifts"' in printed
+        assert 'Run mode is "Create Amplify Shifts"' in caplog.text
         app_main.CreateShifts.assert_called_once_with(
             input_file='x.csv',
             check_mode=True,
@@ -90,11 +83,11 @@ class TestMainRunModeBanners:
             output_verbosity='simple'
         )
 
-    def test_get_mode_prints_banner_and_runs(self, app_main):
-        app_main.main(['get_gcal_events', '--gcal-name', 'events'])
+    def test_get_mode_logs_banner_and_runs(self, app_main, caplog):
+        with caplog.at_level(logging.INFO, logger='star_pass'):
+            app_main.main(['get_gcal_events', '--gcal-name', 'events'])
 
-        printed = _printed(app_main)
-        assert 'Run mode is "Get Google Calendar Events"' in printed
+        assert 'Run mode is "Get Google Calendar Events"' in caplog.text
         app_main.GCALData.assert_called_once_with(gcal_name='events')
 
     def test_get_mode_alias(self, app_main):


### PR DESCRIPTION
Add app/star_pass/_logging.py: an idempotently-configured package logger (get_logger) whose level comes from the LOG_LEVEL environment variable (default INFO) and whose records are formatted to stderr. The logger keeps propagation enabled so pytest's caplog can capture records while production sees no duplicates (the root logger has no handler).

Convert diagnostic and status output to logging: the invalid-calendar and send_api_request error/exit paths and the HTTP response-status line in _helpers, the invalid-calendar-data path in gcal_data, and the run-mode banners in __main__. Secret redaction is preserved on the error paths. Inline progress and user-facing report output (shift previews, JSON) stay on Helpers.printer.

Fix the printer default-argument smell: file defaulted to sys.stdout, which bound the stream once at import and defeated stdout-capture fixtures. It now defaults to None and resolves sys.stdout at call time.

The project pylint config sets logging-format-style=new, under which %s-style args raise logging-too-many-args while brace-style args break at runtime (stdlib interpolates msg % args). Messages are therefore pre-formatted with f-strings and passed with no logging args, which is both lint-clean and runtime-correct.

Update the entry-point and redaction tests to assert via caplog, add LOG_LEVEL to .env.example, and document _logging.py in CLAUDE.md.

Fixes #152 