### PR TITLE
Add HTTP retry with backoff and raise the default timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,11 @@ GCAL_TOKEN=your-google-calendar-api-key
 
 # --- Optional: HTTP behavior ---
 # Request timeout in whole seconds.
-# HTTP_TIMEOUT=3
+# HTTP_TIMEOUT=10
+# Total retry attempts for transient failures (idempotent methods).
+# HTTP_RETRY_TOTAL=3
+# Exponential backoff factor between retries, in seconds.
+# HTTP_RETRY_BACKOFF_FACTOR=0.5
 
 # --- Optional: Logging ---
 # Minimum log level: DEBUG, INFO, WARNING, ERROR, or CRITICAL.

--- a/app/star_pass/_defaults.py
+++ b/app/star_pass/_defaults.py
@@ -112,9 +112,29 @@ BASE_GCAL_URL = getenv(
 HTTP_TIMEOUT = int(
     getenv(
         'HTTP_TIMEOUT',
+        '10'
+    )
+)
+
+# HTTP retry configuration
+# Total retry attempts for transient failures.
+HTTP_RETRY_TOTAL = int(
+    getenv(
+        'HTTP_RETRY_TOTAL',
         '3'
     )
 )
+# Exponential backoff factor between retries, in seconds.
+HTTP_RETRY_BACKOFF_FACTOR = float(
+    getenv(
+        'HTTP_RETRY_BACKOFF_FACTOR',
+        '0.5'
+    )
+)
+# Response status codes that trigger a retry (idempotent methods only;
+# see Helpers._build_session).  urllib3 never retries a POST body-write
+# on these, so shift-creating POSTs are not automatically re-sent.
+HTTP_RETRY_STATUS_FORCELIST = (429, 500, 502, 503, 504)
 
 # Logging configuration
 LOG_LEVEL = getenv(

--- a/app/star_pass/_helpers.py
+++ b/app/star_pass/_helpers.py
@@ -12,7 +12,9 @@ import sys
 from dateparser import parse
 from dotenv import load_dotenv
 from thefuzz import fuzz, process
-from requests import exceptions, request, Response
+from requests import exceptions, Response, Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 # Imports - Local
 from . import _defaults
@@ -23,6 +25,9 @@ AMPLIFY_DATE_TIME_FORMAT = _defaults.AMPLIFY_DATE_TIME_FORMAT
 ENV_FILE_PATH = _defaults.ENV_FILE_PATH
 FILE_ENCODING = _defaults.FILE_ENCODING
 GCAL_CALENDARS = _defaults.GCAL_CALENDARS
+HTTP_RETRY_BACKOFF_FACTOR = _defaults.HTTP_RETRY_BACKOFF_FACTOR
+HTTP_RETRY_STATUS_FORCELIST = _defaults.HTTP_RETRY_STATUS_FORCELIST
+HTTP_RETRY_TOTAL = _defaults.HTTP_RETRY_TOTAL
 SHIFTS_INFO = _defaults.SHIFTS_INFO
 SIMPLE_DATE_FORMAT = _defaults.SIMPLE_DATE_FORMAT
 SIMPLE_TIME_FORMAT = _defaults.SIMPLE_TIME_FORMAT
@@ -433,6 +438,40 @@ class Helpers:
 
         return redacted
 
+    def _build_session(self) -> Session:
+        """ Build a requests Session with retry and backoff configured.
+
+            Transient failures are retried with exponential backoff.
+            The urllib3 default set of allowed methods is used, so only
+            idempotent methods (GET, HEAD, PUT, DELETE, OPTIONS, TRACE)
+            are retried on read errors or the status forcelist.  A POST
+            (used to create Amplify shifts) is retried only on a
+            connection error that occurred before the request reached
+            the server, which cannot create a duplicate shift.
+
+            Args:
+                None.
+
+            Returns:
+                session (requests.Session):
+                    A session whose HTTP and HTTPS adapters retry
+                    transient failures.
+        """
+
+        retry = Retry(
+            total=HTTP_RETRY_TOTAL,
+            backoff_factor=HTTP_RETRY_BACKOFF_FACTOR,
+            status_forcelist=HTTP_RETRY_STATUS_FORCELIST,
+            raise_on_status=False
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+
+        session = Session()
+        session.mount('https://', adapter)
+        session.mount('http://', adapter)
+
+        return session
+
     def send_api_request(
             self,
             api_request_data: Dict,
@@ -469,9 +508,10 @@ class Helpers:
                     HTTP server response object.
         """
 
-        # Send API request
+        # Send the API request through a retry-enabled session
+        session = self._build_session()
         try:
-            response = request(**api_request_data)
+            response = session.request(**api_request_data)
         # Handle TCP Connection Errors
         except (
             exceptions.ConnectionError,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,6 +6,7 @@
     the real behavior and notes the discrepancy.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring
+# pylint: disable=protected-access
 
 # Imports - Python Standard Library
 import logging
@@ -131,14 +132,16 @@ class TestSendApiRequestRedaction:
         # bandit B105 hardcoded-password finding on the test value.
         sentinel = 'TOPSECRET'
 
-        def raise_conn_error(**_kwargs):
+        def raise_conn_error(_self, **_kwargs):
             raise _helpers.exceptions.ConnectionError(
                 f'Failed for url https://x/events?key={sentinel}'
             )
 
-        # Force the HTTP call to raise, and capture the error record
-        # that is logged before the program exits.
-        monkeypatch.setattr(_helpers, 'request', raise_conn_error)
+        # Force the session's HTTP call to raise, and capture the error
+        # record that is logged before the program exits.
+        monkeypatch.setattr(
+            _helpers.Session, 'request', raise_conn_error
+        )
 
         # The real exit_program raises SystemExit after logging.
         with caplog.at_level(logging.ERROR, logger='star_pass'):
@@ -153,3 +156,24 @@ class TestSendApiRequestRedaction:
 
         assert sentinel not in caplog.text
         assert 'REDACTED' in caplog.text
+
+
+class TestBuildSession:
+    def test_session_retry_is_configured(self, helpers):
+        session = helpers._build_session()
+        retry = session.get_adapter('https://example.test').max_retries
+
+        assert retry.total == 3
+        assert retry.backoff_factor == 0.5
+        assert 429 in retry.status_forcelist
+        assert 503 in retry.status_forcelist
+
+    def test_post_is_not_retried(self, helpers):
+        # POST creates Amplify shifts; it must not be auto-retried on a
+        # read error or bad status, which could duplicate a shift. The
+        # urllib3 default allowed-methods set excludes POST.
+        session = helpers._build_session()
+        retry = session.get_adapter('https://example.test').max_retries
+
+        assert 'POST' not in retry.allowed_methods
+        assert 'GET' in retry.allowed_methods


### PR DESCRIPTION
send_api_request previously issued a single requests.request call with a 3-second timeout and no retry, exiting on the first transient failure.

Route requests through a Session built by a new Helpers._build_session, which mounts an HTTPAdapter with a urllib3 Retry: HTTP_RETRY_TOTAL attempts (default 3) with an HTTP_RETRY_BACKOFF_FACTOR (default 0.5s) exponential backoff, retrying the HTTP_RETRY_STATUS_FORCELIST codes (429/500/502/503/ 504). The retry uses urllib3's default allowed-methods set, so only idempotent methods are retried on read errors or bad statuses; a shift-creating POST is retried only on a pre-send connection error, which cannot duplicate a shift. raise_on_status is False so a final bad status still flows to raise_for_status and the existing status-code error path.

Raise the default HTTP_TIMEOUT from 3 to 10 seconds. All three retry settings and the timeout are environment-overridable (see .env.example) following the config pattern from the earlier config-to-env change.

Update the redaction test to patch Session.request, and add tests asserting the retry configuration and that POST is excluded from retryable methods.