### PR TITLE
Pin dependencies and fix the console-script entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,11 @@ classifiers = [
   "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-  "python_dotenv",
-  "pandas",
-  "python-Levenshtein",
-  "thefuzz",
-  "requests"
+  "python_dotenv==1.2.2",
+  "pandas==3.0.3",
+  "python-Levenshtein==0.27.3",
+  "thefuzz==0.22.1",
+  "requests==2.34.2"
 ]
 description = "Tool to automate manual volunteer management in Galaxy Digital Amplify."
 dynamic = ["version"]
@@ -34,7 +34,7 @@ readme = "README.md"
 requires-python = ">= 3.12"
 
 [project.scripts]
-star-pass = "app.star_pass.__main__:main"
+star-pass = "app.__main__:main"
 
 [project.urls]
 Repository = "https://github.com/rcrderby/star-pass.git"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,15 +1,15 @@
 # .env file support
-python_dotenv
+python_dotenv==1.2.2
 
 # Excel spreadsheet management
-openpyxl
+openpyxl==3.1.5
 
 # Pandas data structures
-pandas
+pandas==3.0.3
 
 # Python fuzzy string matching
-python-Levenshtein
-thefuzz
+python-Levenshtein==0.27.3
+thefuzz==0.22.1
 
 # Python HTTP requests
-requests
+requests==2.34.2

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,45 +1,45 @@
 # .env file support
-python_dotenv
+python_dotenv==1.2.2
 
 # Data formats
-pyyaml
+pyyaml==6.0.3
 
 # Excel spreadsheet management
-openpyxl
+openpyxl==3.1.5
 
 # Date parsing
-dateparser
+dateparser==1.4.1
 
 # HTTP requests
-requests
+requests==2.34.2
 
 # JSON Schema validation
-jsonschema
+jsonschema==4.26.0
 
 # Pandas data structures
-pandas
+pandas==3.0.3
 
 # Python formatting
-autopep8
-flake8
-pylint
+autopep8==2.3.2
+flake8==7.3.0
+pylint==4.0.6
 
 # Python fuzzy string matching
-python-Levenshtein
-thefuzz
+python-Levenshtein==0.27.3
+thefuzz==0.22.1
 
 # Python interpreter
-ipython
+ipython==9.15.0
 
 # Python package versioning
-bump
+bump==1.4.0
 
 # Python testing
-pytest
-pytest-cov
+pytest==9.1.1
+pytest-cov==7.1.0
 
 # Static code analysis
-bandit
+bandit==1.9.4
 
 # YAML formatting
-yamllint
+yamllint==1.38.0

--- a/requirements/requirements_pytest.txt
+++ b/requirements/requirements_pytest.txt
@@ -1,15 +1,15 @@
 # Application runtime dependencies -- required to import the modules
 # under test. The CI pytest job installs only this file, so the runtime
 # packages must be listed here alongside the test tooling.
-python_dotenv
-dateparser
-jsonschema
-pandas
-pyyaml
-python-Levenshtein
-thefuzz
-requests
+python_dotenv==1.2.2
+dateparser==1.4.1
+jsonschema==4.26.0
+pandas==3.0.3
+pyyaml==6.0.3
+python-Levenshtein==0.27.3
+thefuzz==0.22.1
+requests==2.34.2
 
 # Python testing
-pytest
-pytest-cov
+pytest==9.1.1
+pytest-cov==7.1.0

--- a/requirements/requirements_static_code_analysis.txt
+++ b/requirements/requirements_static_code_analysis.txt
@@ -1,2 +1,2 @@
 # Static code analysis
-bandit
+bandit==1.9.4


### PR DESCRIPTION
Pin every declared dependency to an exact version across pyproject.toml and all four requirements files, using the known-good versions from the working environment (verified by pip check and the passing test suite), so installs are reproducible. openpyxl, autopep8, ipython, and bump were not previously installed here; they were installed to capture their exact versions.

Also fix the star-pass console-script entry point, which referenced the nonexistent module app.star_pass.__main__; the entry point lives in app/__main__.py, so point it at app.__main__:main.