### PR TITLE
Select run mode with option flags instead of subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,16 +41,15 @@ through the Amplify API. It is run once per month.
 ## Running the workflow
 
 ```bash
-# Run modes are argparse subcommands (aliases: c, g). Use --help or
-# <mode> --help for details.
+# The run mode is a flag: -g/--get-gcal-events or
+# -c/--create-amplify-shifts. Use --help for the full option list.
 
 # 1. Collect Google Calendar events into a timestamped CSV.
-./app/__main__.py get_gcal_events --gcal-name practices
-./app/__main__.py get_gcal_events --gcal-name events
+./app/__main__.py -g -n practices
+./app/__main__.py -g -n events
 
-# 2. Create Amplify shifts from a CSV (--check-mode true is a dry run).
-./app/__main__.py create_amplify_shifts \
-  --input-file gcal_shifts_<timestamp>.csv --check-mode true
+# 2. Create Amplify shifts from a CSV (-C true is a dry run).
+./app/__main__.py -c -i gcal_shifts_<timestamp>.csv -C true
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -38,23 +38,23 @@ This tool automates bulk operations on the Galaxy Digital Amplify volunteer mana
 
 ## Usage
 
-Run `./app/__main__.py --help` to list the run modes, or `./app/__main__.py <mode> --help` for the options of a specific mode. Each mode has a single-letter alias (`c` and `g`).
+Select the run mode with a flag: `-g`/`--get-gcal-events` or `-c`/`--create-amplify-shifts`. Every input has a short and long form. Run `./app/__main__.py --help` for the full list.
 
 1. Collect Google Calendar Shift data and save shift data in a formatted CSV file:
 
     ```bash
     # Get events from the "Practices" calendar
-    ./app/__main__.py get_gcal_events --gcal-name practices
+    ./app/__main__.py -g -n practices
 
     # Get events from the "Events" calendar
-    ./app/__main__.py get_gcal_events --gcal-name events
+    ./app/__main__.py --get-gcal-events --gcal-name events
     ```
 
 2. Create Amplify Shifts using formatted CSV file data:
 
     ```bash
-    # Dry run (default); add --check-mode false to send live requests
-    ./app/__main__.py create_amplify_shifts \
-        --input-file gcal_shifts_2099-01-01T00_00_00_000000.csv \
-        --check-mode false
+    # Dry run (default); add -C false to send live requests
+    ./app/__main__.py -c \
+        -i gcal_shifts_2099-01-01T00_00_00_000000.csv \
+        -C false
     ```

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -18,6 +18,14 @@ VERBOSITY_LEVELS = _defaults.VERBOSITY_LEVELS
 # the choices stay in sync with any deployment overrides.
 GCAL_NAMES = tuple(_defaults.GCAL_CALENDARS)
 
+# Hand-written usage so the help clearly shows which options are
+# mandatory (unbracketed) and optional (bracketed) for each run mode.
+USAGE = (
+    'star-pass -g -n {events,practices}\n'
+    '       star-pass -c -i INPUT_FILE [-C {true,false}] '
+    '[-o {basic,simple,detailed}]'
+)
+
 # Initialize helper methods
 helpers = Helpers()
 
@@ -58,70 +66,72 @@ def _bool_arg(
 def build_parser() -> argparse.ArgumentParser:
     """ Build the command-line argument parser.
 
-        Defines a subcommand per run mode ('create_amplify_shifts' and
-        'get_gcal_events', each with a single-letter alias) so the tool
-        exposes a real '--help', validates arguments, and returns a
-        non-zero exit code on misuse.
+        The run mode is selected by one of two mutually-exclusive flags
+        ('-g/--get-gcal-events' or '-c/--create-amplify-shifts'); each
+        input is an option with a short and long form.  Options that are
+        required for a mode cannot be marked required at the argparse
+        level (they are only required within a mode), so 'main' validates
+        them explicitly; the help text and usage line mark them.
 
         Args:
             None.
 
         Returns:
             parser (argparse.ArgumentParser):
-                The configured top-level argument parser.
+                The configured argument parser.
     """
 
     parser = argparse.ArgumentParser(
         prog='star-pass',
+        usage=USAGE,
         description=(
             'Automate volunteer-shift management in Galaxy Digital '
             'Amplify.'
         )
     )
 
-    # A run mode is required; each subcommand carries its own arguments.
-    subparsers = parser.add_subparsers(
-        dest='mode',
-        required=True,
-        metavar='mode'
-    )
-
-    # Run mode: create Amplify shifts from a CSV file (alias: c)
-    create_parser = subparsers.add_parser(
-        'create_amplify_shifts',
-        aliases=['c'],
-        help='Create Amplify shifts from a formatted CSV file.'
-    )
-    create_parser.add_argument(
-        '--input-file',
-        required=True,
-        help='Name of the CSV file to read shift data from.'
-    )
-    create_parser.add_argument(
-        '--check-mode',
-        type=_bool_arg,
-        default=True,
-        metavar='{true,false}',
-        help='Prepare requests without sending them. Default: true.'
-    )
-    create_parser.add_argument(
-        '--output-verbosity',
-        choices=VERBOSITY_LEVELS,
-        default=VERBOSITY_LEVELS[0],
-        help=f'Amount of detail to display. Default: {VERBOSITY_LEVELS[0]}.'
-    )
-
-    # Run mode: collect Google Calendar events into a CSV file (alias: g)
-    gcal_parser = subparsers.add_parser(
-        'get_gcal_events',
-        aliases=['g'],
+    # Run mode: exactly one flag is required
+    mode_group = parser.add_argument_group('run mode (choose one)')
+    mode = mode_group.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        '-g', '--get-gcal-events',
+        action='store_true',
         help='Collect events from a Google Calendar into a CSV file.'
     )
-    gcal_parser.add_argument(
-        '--gcal-name',
-        required=True,
+    mode.add_argument(
+        '-c', '--create-amplify-shifts',
+        action='store_true',
+        help='Create Amplify shifts from a formatted CSV file.'
+    )
+
+    # Options for 'get-gcal-events' mode
+    get_group = parser.add_argument_group('get-events options')
+    get_group.add_argument(
+        '-n', '--gcal-name',
         choices=GCAL_NAMES,
-        help='Name of the Google Calendar to collect events from.'
+        default=None,
+        help='Google Calendar to collect (required with -g).'
+    )
+
+    # Options for 'create-amplify-shifts' mode
+    create_group = parser.add_argument_group('create-shifts options')
+    create_group.add_argument(
+        '-i', '--input-file',
+        default=None,
+        help='CSV file to read shift data from (required with -c).'
+    )
+    create_group.add_argument(
+        '-C', '--check-mode',
+        type=_bool_arg,
+        default=None,
+        metavar='{true,false}',
+        help='Dry run without sending requests (default: true).'
+    )
+    create_group.add_argument(
+        '-o', '--output-verbosity',
+        choices=VERBOSITY_LEVELS,
+        default=None,
+        help='Amount of detail to display (default: basic).'
     )
 
     return parser
@@ -146,23 +156,27 @@ def main(
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    # Run the application in 'create_amplify_shifts' mode
-    if args.mode in ('create_amplify_shifts', 'c'):
-        # Announce the run mode
-        logger.info(
-            'Run mode is "Create Amplify Shifts"'
-        )
-        # Create CreateShifts object
-        shifts = CreateShifts(
-            input_file=args.input_file,
-            check_mode=args.check_mode,
-            output_verbosity=args.output_verbosity
-        )
-        # Create shifts
-        shifts.create_new_shifts()
-
     # Run the application in 'get_gcal_events' mode
-    elif args.mode in ('get_gcal_events', 'g'):
+    if args.get_gcal_events:
+        # Validate that only get-mode options were supplied
+        if args.gcal_name is None:
+            parser.error(
+                '-g/--get-gcal-events requires -n/--gcal-name'
+            )
+        if any(
+            value is not None
+            for value in (
+                args.input_file,
+                args.check_mode,
+                args.output_verbosity
+            )
+        ):
+            parser.error(
+                '-i/--input-file, -C/--check-mode, and '
+                '-o/--output-verbosity are only valid with '
+                '-c/--create-amplify-shifts'
+            )
+
         # Announce the run mode
         logger.info(
             'Run mode is "Get Google Calendar Events"'
@@ -171,6 +185,42 @@ def main(
         GCALData(
             gcal_name=args.gcal_name
         )
+
+    # Run the application in 'create_amplify_shifts' mode (argparse
+    # guarantees exactly one mode flag, so this is the create case)
+    else:
+        # Validate that only create-mode options were supplied
+        if args.input_file is None:
+            parser.error(
+                '-c/--create-amplify-shifts requires -i/--input-file'
+            )
+        if args.gcal_name is not None:
+            parser.error(
+                '-n/--gcal-name is only valid with -g/--get-gcal-events'
+            )
+
+        # Apply defaults for the optional create-mode arguments
+        check_mode = (
+            True if args.check_mode is None else args.check_mode
+        )
+        output_verbosity = (
+            args.output_verbosity
+            if args.output_verbosity is not None
+            else VERBOSITY_LEVELS[0]
+        )
+
+        # Announce the run mode
+        logger.info(
+            'Run mode is "Create Amplify Shifts"'
+        )
+        # Create CreateShifts object
+        shifts = CreateShifts(
+            input_file=args.input_file,
+            check_mode=check_mode,
+            output_verbosity=output_verbosity
+        )
+        # Create shifts
+        shifts.create_new_shifts()
 
     return None
 

--- a/app/__version__.py
+++ b/app/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 """ star_pass package version file. """
 
-__version__ = '1.6.0'
+__version__ = '1.7.0'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,11 +4,9 @@
     by file path. CreateShifts, GCALData, and the module-level helpers
     object are replaced with mocks so that main() exercises only the
     argument parsing, run-mode dispatch, and banner output -- no CSV is
-    read, no API call is made, and banner text is asserted via the
-    mocked printer (the real printer binds sys.stdout at import time,
-    which defeats stdout capture fixtures). The mocked helpers keeps the
-    real convert_to_bool so that --check-mode parsing is exercised for
-    real.
+    read and no API call is made. Run-mode banners are asserted through
+    the 'star_pass' logger via caplog. The mocked helpers keeps the real
+    convert_to_bool so that --check-mode parsing is exercised for real.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring
 # pylint: disable=redefined-outer-name
@@ -40,9 +38,9 @@ def app_main():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    # Replace collaborators so main() performs no real work and banner
-    # output is observable through the mocked printer. Preserve the real
-    # convert_to_bool so argparse validates --check-mode as in production.
+    # Replace collaborators so main() performs no real work. Preserve the
+    # real convert_to_bool so argparse validates --check-mode as in
+    # production.
     mock_helpers = Mock()
     mock_helpers.convert_to_bool = Helpers().convert_to_bool
     module.helpers = mock_helpers
@@ -51,12 +49,10 @@ def app_main():
     return module
 
 
-class TestMainRunModeBanners:
-    def test_create_mode_logs_banner_and_runs(self, app_main, caplog):
+class TestMainRunModeDispatch:
+    def test_create_mode_short_flags(self, app_main, caplog):
         with caplog.at_level(logging.INFO, logger='star_pass'):
-            app_main.main(
-                ['create_amplify_shifts', '--input-file', 'x.csv']
-            )
+            app_main.main(['-c', '-i', 'x.csv'])
 
         assert 'Run mode is "Create Amplify Shifts"' in caplog.text
         app_main.CreateShifts.assert_called_once_with(
@@ -67,10 +63,10 @@ class TestMainRunModeBanners:
         app_main.CreateShifts.return_value.create_new_shifts \
             .assert_called_once()
 
-    def test_create_mode_alias_and_options(self, app_main):
+    def test_create_mode_long_flags_and_options(self, app_main):
         app_main.main(
             [
-                'c',
+                '--create-amplify-shifts',
                 '--input-file', 'x.csv',
                 '--check-mode', 'false',
                 '--output-verbosity', 'simple'
@@ -83,63 +79,69 @@ class TestMainRunModeBanners:
             output_verbosity='simple'
         )
 
-    def test_get_mode_logs_banner_and_runs(self, app_main, caplog):
+    def test_get_mode_short_flags(self, app_main, caplog):
         with caplog.at_level(logging.INFO, logger='star_pass'):
-            app_main.main(['get_gcal_events', '--gcal-name', 'events'])
+            app_main.main(['-g', '-n', 'events'])
 
         assert 'Run mode is "Get Google Calendar Events"' in caplog.text
         app_main.GCALData.assert_called_once_with(gcal_name='events')
 
-    def test_get_mode_alias(self, app_main):
-        app_main.main(['g', '--gcal-name', 'practices'])
+    def test_get_mode_long_flags(self, app_main):
+        app_main.main(['--get-gcal-events', '--gcal-name', 'practices'])
 
         app_main.GCALData.assert_called_once_with(gcal_name='practices')
 
 
 class TestMainArgumentErrors:
-    def test_missing_mode_exits_nonzero(self, app_main):
+    def test_no_mode_exits_nonzero(self, app_main):
         with pytest.raises(SystemExit) as exc_info:
             app_main.main([])
         assert exc_info.value.code != 0
         app_main.CreateShifts.assert_not_called()
         app_main.GCALData.assert_not_called()
 
-    def test_invalid_mode_exits_nonzero(self, app_main):
+    def test_both_modes_exits_nonzero(self, app_main):
         with pytest.raises(SystemExit) as exc_info:
-            app_main.main(['bogus'])
+            app_main.main(['-c', '-g', '-i', 'x.csv'])
         assert exc_info.value.code != 0
 
-    def test_missing_required_input_file_exits_nonzero(self, app_main):
+    def test_create_without_input_file_exits_nonzero(self, app_main):
         with pytest.raises(SystemExit) as exc_info:
-            app_main.main(['create_amplify_shifts'])
+            app_main.main(['-c'])
+        assert exc_info.value.code != 0
+        app_main.CreateShifts.assert_not_called()
+
+    def test_get_without_gcal_name_exits_nonzero(self, app_main):
+        with pytest.raises(SystemExit) as exc_info:
+            app_main.main(['-g'])
+        assert exc_info.value.code != 0
+        app_main.GCALData.assert_not_called()
+
+    def test_get_mode_rejects_create_option(self, app_main):
+        with pytest.raises(SystemExit) as exc_info:
+            app_main.main(['-g', '-n', 'events', '-i', 'x.csv'])
+        assert exc_info.value.code != 0
+        app_main.GCALData.assert_not_called()
+
+    def test_create_mode_rejects_gcal_name(self, app_main):
+        with pytest.raises(SystemExit) as exc_info:
+            app_main.main(['-c', '-i', 'x.csv', '-n', 'events'])
         assert exc_info.value.code != 0
         app_main.CreateShifts.assert_not_called()
 
     def test_invalid_check_mode_value_exits_nonzero(self, app_main):
         with pytest.raises(SystemExit) as exc_info:
-            app_main.main(
-                [
-                    'create_amplify_shifts',
-                    '--input-file', 'x.csv',
-                    '--check-mode', 'maybe'
-                ]
-            )
+            app_main.main(['-c', '-i', 'x.csv', '-C', 'maybe'])
         assert exc_info.value.code != 0
 
     def test_invalid_verbosity_choice_exits_nonzero(self, app_main):
         with pytest.raises(SystemExit) as exc_info:
-            app_main.main(
-                [
-                    'create_amplify_shifts',
-                    '--input-file', 'x.csv',
-                    '--output-verbosity', 'loud'
-                ]
-            )
+            app_main.main(['-c', '-i', 'x.csv', '-o', 'loud'])
         assert exc_info.value.code != 0
 
     def test_invalid_gcal_name_choice_exits_nonzero(self, app_main):
         with pytest.raises(SystemExit) as exc_info:
-            app_main.main(['get_gcal_events', '--gcal-name', 'nope'])
+            app_main.main(['-g', '-n', 'nope'])
         assert exc_info.value.code != 0
 
     def test_help_exits_zero(self, app_main):


### PR DESCRIPTION
Replace the positional subcommand interface (create_amplify_shifts/c, get_gcal_events/g) with option flags, so the run mode is chosen the same way as every other input and each option has a short and long form.

The mode is a required, mutually-exclusive pair: -g/--get-gcal-events and -c/--create-amplify-shifts. Inputs: -n/--gcal-name, -i/--input-file, -C/--check-mode {true,false} (default true), -o/--output-verbosity.

argparse cannot mark an option required only within a mode, so main() validates explicitly with parser.error() (which exits 2 with the usage line): each mode requires its own option and rejects the other mode's options, rather than silently ignoring them. Per-mode options default to None so "not supplied" is distinguishable, and the defaults (check_mode true, verbosity basic) are applied in the create branch. A hand-written usage line plus argument groups and "(required with -g/-c)" annotations keep --help clear about what is mandatory vs optional.

Rewrite the entry-point tests for the flag interface (short and long forms, both-modes and wrong-mode-option errors), update the README and CLAUDE.md usage examples, and bump the version to 1.7.0.

Fixes #150 